### PR TITLE
Hash map implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(hello hello.c hello.h vector.h network.h hash.h hash_table hash_table.c hash_table.h)
+add_library(hash_table vector.h network.h hash.h hash_table.c hash_table.h)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(hello hello.c hello.h vector.h network.h)
+add_library(hello hello.c hello.h vector.h network.h hash.h hash_table hash_table.c hash_table.h)
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,0 +1,17 @@
+#include <string.h> 
+
+/* http://www.cse.yorku.ca/~oz/hash.html
+ * A copy of the djb2 hash function by https://en.wikipedia.org/wiki/Daniel_J._Bernstein
+ * It is not cryptographically secure, but is effective and fast in practice. 
+*/
+unsigned long djb2(unsigned char *str) {
+    // NOLINTBEGIN -- this isn't our code makes no sense to change it for the linter
+    unsigned long hash = 5381; 
+    int c;
+    while ((c = *str++))
+        hash = ((hash << 5) + hash) + (long unsigned int) c; /* hash * 33 + c */
+
+    return hash;
+    // NOLINTEND
+}
+

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -1,0 +1,105 @@
+#include "./vector.h"
+#include "./hash.h"
+#include "./hash_table.h"
+#include <string.h>
+
+/* The key/value container for our hash map */
+typedef struct kv_pair {
+    char* key; 
+    void* value; 
+    size_t value_size; 
+} kv_pair;
+
+// create a bucket container for kv_pairs
+vector__(kv_pair, kv_pair)
+
+    /* A hash table is an array of buckets */
+    typedef struct hash_table {
+        vector_kv_pair* buckets;
+        size_t bucket_size; 
+        size_t num_elements;
+    } hash_table;
+
+/* Internal, hash table with custom initial bucket size */
+hash_table __make_table(size_t bucket_size) {
+    hash_table new_table = {malloc(sizeof(vector_kv_pair) * bucket_size), bucket_size, (size_t)0};
+    return new_table;
+}
+/* Creates a new empty hash table */
+hash_table make_table() {
+    return __make_table(2);
+}
+
+/* Returns a key/value pair in the hash_table or a NULL padded struct if it does not exist */
+kv_pair* get_kv_pair(hash_table* in_table, char* key) {
+    // find the bucket for the key
+    size_t bucket = djb2((unsigned char*)key) % in_table->bucket_size;    
+    // walk the bucket
+    for(size_t index = 0; index < (in_table->buckets[bucket].size); index++) {
+        char* ret_key = in_table->buckets[bucket].arr[index].key; 
+        if(strcmp(key, ret_key) == 0) {
+            return &in_table->buckets[bucket].arr[index];
+        }
+    }
+    return NULL;
+}
+
+/* Frees the data used by the hash table */
+void hash_dealloc(hash_table* in_table) {
+
+    free(in_table->buckets);
+    in_table->buckets = NULL;
+}
+
+void hash_realloc(hash_table* in_table);
+void set_value(hash_table* in_table, char* key, void* value, size_t value_size);
+
+/* Reallocs the hash table to handle more elements */
+void hash_realloc(hash_table* in_table) {
+    // allocate a new table with double the bucket size
+    hash_table new_table = __make_table(in_table->bucket_size * 2);
+    // copy elements in
+    for(size_t bucket = 0; bucket < in_table->bucket_size; bucket ++) {
+        for(size_t element = 0; element < in_table->buckets[element].size; element++) {
+            kv_pair cur_pair = in_table->buckets[bucket].arr[element]; 
+            set_value(&new_table, cur_pair.key, cur_pair.value, cur_pair.value_size);
+        }
+    }
+    // swap new table with input table
+    hash_dealloc(in_table);
+    in_table->buckets = new_table.buckets; 
+    in_table->bucket_size *= 2;
+}
+
+/* Updates the value of a key in a hash table */
+void set_value(hash_table* in_table, char* key, void* value, size_t value_size) {
+    kv_pair* get_pair = get_kv_pair(in_table, key);     
+    if(get_pair) {
+        free(get_pair->value); 
+        get_pair->value = malloc(value_size); 
+        memcpy(value, get_pair->value, value_size); // NOLINT
+    }
+    else {
+        if(in_table->num_elements == in_table->bucket_size) {
+            hash_realloc(in_table);
+        }
+        in_table->num_elements ++;
+        size_t bucket = djb2((unsigned char*)key) % in_table->bucket_size; 
+        kv_pair new_pair = {malloc(strlen(key)), malloc(value_size), value_size};
+        memcpy(key, new_pair.key, strlen(key)); // NOLINT
+        memcpy(value, new_pair.value, value_size); // NOLINT
+        push_vec_kv_pair(&in_table->buckets[bucket], new_pair);
+    }
+}
+
+#include <stdio.h>
+int main() {
+   hash_table table = make_table(); 
+   char* key = "foobar";
+   int val = 1;
+  set_value(&table, key, &val, 1);
+  // kv_pair* kv = get_kv_pair(&table, key);
+ //  printf("%d", kv->value);
+   //printf("%d", *(int*) kv->value);
+
+}

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -77,13 +77,3 @@ void set_value(hash_table* in_table, char* key, void* value, size_t value_size) 
         push_vec_kv_pair(&in_table->buckets[bucket], new_pair);
     }
 }
-
-int main() {
-   hash_table table = make_table(); 
-   char* key = "foobar";
-   int val = 10;
-   set_value(&table, key, &val, 1);
-   kv_pair* kv = get_kv_pair(&table, key);
-   printf("%d\n", *(int*) kv->value);
-
-}

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -1,6 +1,5 @@
 #include "./hash.h"
 #include "./hash_table.h"
-#include <stdio.h>
 #include <string.h>
 
 /* Internal, hash table with custom initial bucket size */
@@ -32,7 +31,13 @@ kv_pair* get_kv_pair(hash_table* in_table, char* key) {
 
 /* Frees the data used by the hash table */
 void hash_dealloc(hash_table* in_table) {
-
+    for(size_t bucket = 0; bucket < in_table->bucket_size; bucket++) {
+        for(size_t elem = 0; elem < in_table->buckets[bucket].size; elem ++) {
+            free(in_table->buckets[bucket].arr[elem].key);
+            free(in_table->buckets[bucket].arr[elem].value);
+        }
+        free_vec_kv_pair(&in_table->buckets[bucket]);
+    }
     free(in_table->buckets);
     in_table->buckets = NULL;
 }
@@ -60,17 +65,14 @@ void set_value(hash_table* in_table, char* key, void* value, size_t value_size) 
     if(get_pair) {
         free(get_pair->value); 
         get_pair->value = malloc(value_size); 
-        memcpy(value, get_pair->value, value_size); // NOLINT
+        memcpy(get_pair->value, value, value_size); // NOLINT
     }
     else {
-        puts("not found");        
         if(in_table->num_elements == in_table->bucket_size) {
-            puts("realloced");
             hash_realloc(in_table); // NOLINT
         }
         in_table->num_elements ++;
         size_t bucket = djb2((unsigned char*)key) % in_table->bucket_size;  // NOLINT
-        printf("%d\n", (int)bucket);
         kv_pair new_pair = {malloc(strlen(key)+1), malloc(value_size), value_size};
         memcpy(new_pair.key, key, strlen(key)+1); // NOLINT
         memcpy(new_pair.value, value, value_size); // NOLINT

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -1,34 +1,19 @@
-#include "./vector.h"
-#include <stdio.h>
 #include "./hash.h"
 #include "./hash_table.h"
+#include <stdio.h>
 #include <string.h>
 
-/* The key/value container for our hash map */
-typedef struct kv_pair {
-    char* key; 
-    void* value; 
-    size_t value_size; 
-} kv_pair;
-
-// create a bucket container for kv_pairs
-vector__(kv_pair, kv_pair)
-
-    /* A hash table is an array of buckets */
-    typedef struct hash_table {
-        vector_kv_pair* buckets;
-        size_t bucket_size; 
-        size_t num_elements;
-    } hash_table;
-
 /* Internal, hash table with custom initial bucket size */
-hash_table __make_table(size_t bucket_size) {
+hash_table make_table__(size_t bucket_size) {
     hash_table new_table = {malloc(sizeof(vector_kv_pair) * bucket_size), bucket_size, 0};
+    for(size_t vec = 0; vec < bucket_size; vec++) {
+        new_table.buckets[vec] = new_vec_kv_pair();
+    }
     return new_table;
 }
 /* Creates a new empty hash table */
 hash_table make_table() {
-    return __make_table(2);
+    return make_table__(2);
 }
 
 /* Returns a key/value pair in the hash_table or a NULL padded struct if it does not exist */
@@ -52,18 +37,15 @@ void hash_dealloc(hash_table* in_table) {
     in_table->buckets = NULL;
 }
 
-void hash_realloc(hash_table* in_table);
-void set_value(hash_table* in_table, char* key, void* value, size_t value_size);
-
 /* Reallocs the hash table to handle more elements */
 void hash_realloc(hash_table* in_table) {
     // allocate a new table with double the bucket size
-    hash_table new_table = __make_table(in_table->bucket_size * 2);
+    hash_table new_table = make_table__(in_table->bucket_size * 2);
     // copy elements in
     for(size_t bucket = 0; bucket < in_table->bucket_size; bucket ++) {
         for(size_t element = 0; element < in_table->buckets[element].size; element++) {
             kv_pair cur_pair = in_table->buckets[bucket].arr[element]; 
-            set_value(&new_table, cur_pair.key, cur_pair.value, cur_pair.value_size);
+            set_value(&new_table, cur_pair.key, cur_pair.value, cur_pair.value_size); // NOLINT
         }
     }
     // swap new table with input table
@@ -84,10 +66,10 @@ void set_value(hash_table* in_table, char* key, void* value, size_t value_size) 
         puts("not found");        
         if(in_table->num_elements == in_table->bucket_size) {
             puts("realloced");
-            hash_realloc(in_table);
+            hash_realloc(in_table); // NOLINT
         }
         in_table->num_elements ++;
-        size_t bucket = djb2((unsigned char*)key) % in_table->bucket_size; 
+        size_t bucket = djb2((unsigned char*)key) % in_table->bucket_size;  // NOLINT
         printf("%d\n", (int)bucket);
         kv_pair new_pair = {malloc(strlen(key)+1), malloc(value_size), value_size};
         memcpy(new_pair.key, key, strlen(key)+1); // NOLINT

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -1,4 +1,5 @@
 #include "./vector.h"
+#include <stdio.h>
 #include "./hash.h"
 #include "./hash_table.h"
 #include <string.h>
@@ -22,7 +23,7 @@ vector__(kv_pair, kv_pair)
 
 /* Internal, hash table with custom initial bucket size */
 hash_table __make_table(size_t bucket_size) {
-    hash_table new_table = {malloc(sizeof(vector_kv_pair) * bucket_size), bucket_size, (size_t)0};
+    hash_table new_table = {malloc(sizeof(vector_kv_pair) * bucket_size), bucket_size, 0};
     return new_table;
 }
 /* Creates a new empty hash table */
@@ -80,26 +81,27 @@ void set_value(hash_table* in_table, char* key, void* value, size_t value_size) 
         memcpy(value, get_pair->value, value_size); // NOLINT
     }
     else {
+        puts("not found");        
         if(in_table->num_elements == in_table->bucket_size) {
+            puts("realloced");
             hash_realloc(in_table);
         }
         in_table->num_elements ++;
         size_t bucket = djb2((unsigned char*)key) % in_table->bucket_size; 
-        kv_pair new_pair = {malloc(strlen(key)), malloc(value_size), value_size};
-        memcpy(key, new_pair.key, strlen(key)); // NOLINT
-        memcpy(value, new_pair.value, value_size); // NOLINT
+        printf("%d\n", (int)bucket);
+        kv_pair new_pair = {malloc(strlen(key)+1), malloc(value_size), value_size};
+        memcpy(new_pair.key, key, strlen(key)+1); // NOLINT
+        memcpy(new_pair.value, value, value_size); // NOLINT
         push_vec_kv_pair(&in_table->buckets[bucket], new_pair);
     }
 }
 
-#include <stdio.h>
 int main() {
    hash_table table = make_table(); 
    char* key = "foobar";
-   int val = 1;
-  set_value(&table, key, &val, 1);
-  // kv_pair* kv = get_kv_pair(&table, key);
- //  printf("%d", kv->value);
-   //printf("%d", *(int*) kv->value);
+   int val = 10;
+   set_value(&table, key, &val, 1);
+   kv_pair* kv = get_kv_pair(&table, key);
+   printf("%d\n", *(int*) kv->value);
 
 }

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -1,0 +1,35 @@
+#include "./vector.h"
+
+/* The key/value container for our hash map */
+typedef struct kv_pair {
+    char* key; 
+    void* value;
+    size_t value_size; 
+} kv_pair; 
+
+// create a bucket container for kv_pairs
+vector__(kv_pair, kv_pair)
+
+/* A hash table is an array of buckets */
+typedef struct hash_table {
+    vector_kv_pair* buckets;
+    size_t bucket_size; 
+    size_t num_elements;
+} hash_table;
+
+/* Sets a value in the hash table. The key and value is copied by value. */
+void set_value(hash_table* in_table, char* key, void* value, size_t value_size); 
+
+/* Returns a key/value pair in the hash_table or a NULL padded struct if it does not exist */
+kv_pair* get_kv_pair(hash_table* in_table, char* key);
+
+
+/* Create a new hable */
+hash_table make_table(); 
+
+/* Free data used by the hash table */
+void hash_dealloc(hash_table* in_table);
+
+/* Internal */
+void hash_realloc(hash_table* in_table);
+

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,7 +1,8 @@
+#pragma once 
+
 #include <stdio.h> 
 #include <stdlib.h> 
 #include <string.h> 
-#pragma clang diagnostic ignored "-Wstrict-prototypes"
 
 // NOLINTBEGIN -- false warnings from strict-prototypes and macro () enclosure also memcpy warning is non-relevant
 #define vector__(TYPE, NAME)                                              \

--- a/src/vector.h
+++ b/src/vector.h
@@ -14,7 +14,7 @@
     } vector_##NAME;                                                      \
                                                                           \
     /* Inserts an element to the end of the vector */                     \
-    void push_vec_##NAME(vector_##NAME* vec, TYPE element) {              \
+    static void push_vec_##NAME(vector_##NAME* vec, TYPE element) {              \
         if(vec->size == vec->alloc) {                                     \
             TYPE* new_arr = malloc(sizeof(TYPE) * vec->alloc * 2);        \
             memcpy(new_arr, vec->arr, sizeof(TYPE) * vec->alloc * 2);     \
@@ -26,16 +26,16 @@
         vec->arr[vec->size-1] = element;                                  \
     }                                                                     \
     /* Returns a pointer to the alement at a given index in the vector */ \
-    TYPE* get_vec_##NAME(vector_##NAME* vec, size_t idx) {                \
+    static TYPE* get_vec_##NAME(vector_##NAME* vec, size_t idx) {                \
         return &vec->arr[idx];                                            \
     }                                                                     \
     /* Creates a vector container with no elements in it */               \
-    vector_##NAME new_vec_##NAME() {                                      \
+    static vector_##NAME new_vec_##NAME() {                                      \
         vector_##NAME new_struct = {malloc(sizeof(TYPE)), 0, 1};          \
         return new_struct;                                                \
     }                                                                     \
     /* De-allocates all dynamic memory used by the container */           \
-    void free_vec_##NAME(vector_##NAME *vec) {                            \
+    static void free_vec_##NAME(vector_##NAME *vec) {                            \
         free(vec->arr);                                                   \
         vec->arr = NULL;                                                  \
     }                                                                     \
@@ -43,7 +43,7 @@
 
 // define common vector types we might need
 vector__(int, int)
-vector__(char, char)
-vector__(int, intptr)
-vector__(char*, charptr)
+//vector__(char, char)
+//vector__(int, intptr)
+//vector__(char*, charptr)
 

--- a/src/vector.h
+++ b/src/vector.h
@@ -14,7 +14,7 @@
     } vector_##NAME;                                                      \
                                                                           \
     /* Inserts an element to the end of the vector */                     \
-    static void push_vec_##NAME(vector_##NAME* vec, TYPE element) {              \
+    static void push_vec_##NAME(vector_##NAME* vec, TYPE element) {       \
         if(vec->size == vec->alloc) {                                     \
             TYPE* new_arr = malloc(sizeof(TYPE) * vec->alloc * 2);        \
             memcpy(new_arr, vec->arr, sizeof(TYPE) * vec->alloc * 2);     \
@@ -26,24 +26,18 @@
         vec->arr[vec->size-1] = element;                                  \
     }                                                                     \
     /* Returns a pointer to the alement at a given index in the vector */ \
-    static TYPE* get_vec_##NAME(vector_##NAME* vec, size_t idx) {                \
+    static TYPE* get_vec_##NAME(vector_##NAME* vec, size_t idx) {         \
         return &vec->arr[idx];                                            \
     }                                                                     \
     /* Creates a vector container with no elements in it */               \
-    static vector_##NAME new_vec_##NAME() {                                      \
+    static vector_##NAME new_vec_##NAME() {                               \
         vector_##NAME new_struct = {malloc(sizeof(TYPE)), 0, 1};          \
         return new_struct;                                                \
     }                                                                     \
     /* De-allocates all dynamic memory used by the container */           \
-    static void free_vec_##NAME(vector_##NAME *vec) {                            \
+    static void free_vec_##NAME(vector_##NAME *vec) {                     \
         free(vec->arr);                                                   \
         vec->arr = NULL;                                                  \
     }                                                                     \
 // NOLINTEND
-
-// define common vector types we might need
-vector__(int, int)
-//vector__(char, char)
-//vector__(int, intptr)
-//vector__(char*, charptr)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,14 +3,14 @@
 # conversion warnings for test code.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-conversion")
 
-add_executable(test_hello test_hello.c)
-target_link_libraries(test_hello
-  PRIVATE hello 
+add_executable(test_hash_table test_hash_table.c)
+target_link_libraries(test_hash_table
+  PRIVATE hash_table 
   PUBLIC ${CRITERION}
 )
 add_test(
-  NAME test_hello
-  COMMAND test_hello ${CRITERION_FLAGS}
+  NAME test_hash_table
+  COMMAND test_hash_table ${CRITERION_FLAGS}
 )
 
 add_executable(test_vector test_vector.c)

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -1,0 +1,46 @@
+#include <criterion/criterion.h>
+#include <criterion/new/assert.h>
+
+#include "../src/hash_table.h"
+
+// NOLINTBEGIN -- the magic constant warnings are useless here
+Test(test_map, simple_test) {
+    hash_table table = make_table();
+    const* key1 = "key1";
+    const* key2 = "key2";
+    int val1 = 1;
+    int val2 = 2;
+    set_value(&table, key1, &val1, sizeof(val1));
+    set_value(&table, key2, &val2, sizeof(val2));
+
+    kv_pair* kv1 = get_kv_pair(&table, key1); 
+    int res1 = *(int*)kv1->value;
+    cr_assert(eq(int, val1, res1));
+
+    kv_pair* kv2 = get_kv_pair(&table, key2); 
+    int res2 = *(int*)kv2->value;
+    cr_assert(eq(int, val2, res2));
+}
+
+Test(test_map, memory_leak_test) {
+    for(size_t iter = 0; iter < 100000000; iter++) {
+        hash_table table = make_table();
+        const* key1 = "key1";
+        const* key2 = "key2";
+        int val1 = 1;
+        int val2 = 2;
+        set_value(&table, key1, &val1, sizeof(val1));
+        set_value(&table, key2, &val2, sizeof(val2));
+
+        kv_pair* kv1 = get_kv_pair(&table, key1); 
+        int res1 = *(int*)kv1->value;
+        cr_assert(eq(int, val1, res1));
+
+        kv_pair* kv2 = get_kv_pair(&table, key2); 
+        int res2 = *(int*)kv2->value;
+        cr_assert(eq(int, val2, res2));
+    }
+}
+
+
+// NOLINTEND

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -6,8 +6,8 @@
 // NOLINTBEGIN -- the magic constant warnings are useless here
 Test(test_map, simple_test) {
     hash_table table = make_table();
-    const* key1 = "key1";
-    const* key2 = "key2";
+    char* key1 = "key1";
+    char* key2 = "key2";
     int val1 = 1;
     int val2 = 2;
     set_value(&table, key1, &val1, sizeof(val1));
@@ -51,8 +51,8 @@ Test(test_map, advance_test) {
 Test(test_map, memory_leak_test) {
     for(size_t iter = 0; iter < 10000; iter++) {
         hash_table table = make_table();
-        const* key1 = "key1";
-        const* key2 = "key2";
+        char* key1 = "key1";
+        char* key2 = "key2";
         int val1 = 1;
         int val2 = 2;
         set_value(&table, key1, &val1, sizeof(val1));

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -26,7 +26,7 @@ Test(test_map, simple_test) {
 
 // Tested with valgrind against memory leaks
 Test(test_map, advance_test) {
-    for(size_t total_iter = 0; total_iter < 1000000; total_iter++) {
+    for(size_t total_iter = 0; total_iter < 1000; total_iter++) {
         size_t iters = 26;
         hash_table table = make_table();
         for(size_t idx = 0; idx < iters; idx++) {
@@ -49,7 +49,7 @@ Test(test_map, advance_test) {
 
 // Tested with valgrind against memory leaks
 Test(test_map, memory_leak_test) {
-    for(size_t iter = 0; iter < 10000000; iter++) {
+    for(size_t iter = 0; iter < 10000; iter++) {
         hash_table table = make_table();
         const* key1 = "key1";
         const* key2 = "key2";

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -20,10 +20,36 @@ Test(test_map, simple_test) {
     kv_pair* kv2 = get_kv_pair(&table, key2); 
     int res2 = *(int*)kv2->value;
     cr_assert(eq(int, val2, res2));
+
+    hash_dealloc(&table);
 }
 
+// Tested with valgrind against memory leaks
+Test(test_map, advance_test) {
+    for(size_t total_iter = 0; total_iter < 1000000; total_iter++) {
+        size_t iters = 26;
+        hash_table table = make_table();
+        for(size_t idx = 0; idx < iters; idx++) {
+            char key[4] = "abc";
+            key[3] = 'a' + idx;
+            key[4] = '\0';
+            set_value(&table, key, &idx, sizeof(idx));
+        }
+        for(size_t idx = 0; idx < iters; idx++) {
+            char key[4] = "abc";
+            key[3] = 'a' + idx;
+            key[4] = '\0';
+            kv_pair* kv = get_kv_pair(&table, key); 
+            int actual_value = *(int*)kv->value;
+            cr_assert(eq(int, idx, actual_value));
+        }
+        hash_dealloc(&table);
+    }
+}
+
+// Tested with valgrind against memory leaks
 Test(test_map, memory_leak_test) {
-    for(size_t iter = 0; iter < 100000000; iter++) {
+    for(size_t iter = 0; iter < 10000000; iter++) {
         hash_table table = make_table();
         const* key1 = "key1";
         const* key2 = "key2";
@@ -39,8 +65,11 @@ Test(test_map, memory_leak_test) {
         kv_pair* kv2 = get_kv_pair(&table, key2); 
         int res2 = *(int*)kv2->value;
         cr_assert(eq(int, val2, res2));
+
+        hash_dealloc(&table);
     }
 }
+
 
 
 // NOLINTEND

--- a/test/test_vector.c
+++ b/test/test_vector.c
@@ -3,6 +3,8 @@
 
 #include "../src/vector.h"
 
+vector__(int, int) 
+
 // NOLINTBEGIN -- the magic constant warnings are useless here
 Test(vector, vector_int) {
     // add elements to container


### PR DESCRIPTION
Implements a hash map where keys are null terminated C strings ie. `char *` and values are arbitrary types `void*` that specify the number of bytes only. It would probably be helpful to change it later so that the keys of the hashmap can be any type and specify the number of bytes to read for the key only. 

The tests are  decent and I ran valgrind in a loop to double check against the test code. 

```
==208998== Memcheck, a memory error detector
==208998== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==208998== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==208998== Command: ./test_hash_table
==208998== 
==209000== Memcheck, a memory error detector
==209000== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==209000== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==209000== Command: /home/daniel-sudz/Desktop/p2p-networking/build/test/test_hash_table
==209000== 
==209000== 
==209000== HEAP SUMMARY:
==209000==     in use at exit: 383,056 bytes in 1,339 blocks
==209000==   total heap usage: 182,101 allocs, 180,762 frees, 4,495,973 bytes allocated
==209000== 
==209000== LEAK SUMMARY:
==209000==    definitely lost: 0 bytes in 0 blocks
==209000==    indirectly lost: 0 bytes in 0 blocks
==209000==      possibly lost: 0 bytes in 0 blocks
==209000==    still reachable: 383,056 bytes in 1,339 blocks
==209000==         suppressed: 0 bytes in 0 blocks
==209000== Rerun with --leak-check=full to see details of leaked memory
==209000== 
==209000== For lists of detected and suppressed errors, rerun with: -s
==209000== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==209003== Memcheck, a memory error detector
==209003== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==209003== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==209003== Command: /home/daniel-sudz/Desktop/p2p-networking/build/test/test_hash_table
==209003== 
==209003== 
==209003== HEAP SUMMARY:
==209003==     in use at exit: 383,056 bytes in 1,339 blocks
==209003==   total heap usage: 73,101 allocs, 71,762 frees, 1,932,013 bytes allocated
==209003== 
==209003== LEAK SUMMARY:
==209003==    definitely lost: 0 bytes in 0 blocks
==209003==    indirectly lost: 0 bytes in 0 blocks
==209003==      possibly lost: 0 bytes in 0 blocks
==209003==    still reachable: 383,056 bytes in 1,339 blocks
==209003==         suppressed: 0 bytes in 0 blocks
==209003== Rerun with --leak-check=full to see details of leaked memory
==209003== 
==209003== For lists of detected and suppressed errors, rerun with: -s
==209003== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==209006== Memcheck, a memory error detector
==209006== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==209006== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==209006== Command: /home/daniel-sudz/Desktop/p2p-networking/build/test/test_hash_table
==209006== 
==209006== 
==209006== HEAP SUMMARY:
==209006==     in use at exit: 383,056 bytes in 1,339 blocks
==209006==   total heap usage: 3,108 allocs, 1,769 frees, 792,077 bytes allocated
==209006== 
==209006== LEAK SUMMARY:
==209006==    definitely lost: 0 bytes in 0 blocks
==209006==    indirectly lost: 0 bytes in 0 blocks
==209006==      possibly lost: 0 bytes in 0 blocks
==209006==    still reachable: 383,056 bytes in 1,339 blocks
==209006==         suppressed: 0 bytes in 0 blocks
==209006== Rerun with --leak-check=full to see details of leaked memory
==209006== 
==209006== For lists of detected and suppressed errors, rerun with: -s
==209006== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
[====] Synthesis: Tested: 3 | Passing: 3 | Failing: 0 | Crashing: 0 
==208998== 
==208998== HEAP SUMMARY:
==208998==     in use at exit: 383,056 bytes in 1,339 blocks
==208998==   total heap usage: 3,369 allocs, 2,030 frees, 838,459 bytes allocated
==208998== 
==208998== LEAK SUMMARY:
==208998==    definitely lost: 0 bytes in 0 blocks
==208998==    indirectly lost: 0 bytes in 0 blocks
==208998==      possibly lost: 0 bytes in 0 blocks
==208998==    still reachable: 383,056 bytes in 1,339 blocks
==208998==         suppressed: 0 bytes in 0 blocks
==208998== Rerun with --leak-check=full to see details of leaked memory
==208998== 
==208998== For lists of detected and suppressed errors, rerun with: -s
==208998== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```