### PR TITLE
Example for I/O event loop with epoll (rebase)

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -1,0 +1,94 @@
+#include <stdio.h> 
+#include <stdlib.h> 
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/epoll.h>
+
+
+#include "./network.h"
+
+
+/* When epoll notifies us of a connnection of our socket, we want to accept all of them 
+   and add them to our listening queue.
+ */
+void on_connection(int epoll_c, int file_descriptor) {
+    puts("attempting to accept connection");
+    // accept all possible connections 
+    while(1) {
+        struct sockaddr_in6 in_address; 
+        socklen_t adress_length = sizeof(struct sockaddr);
+        int accept_res = accept(file_descriptor, (struct sockaddr*) &in_address, &adress_length);
+        if(accept_res < 0) {
+            // no more connection left
+            if(errno == EWOULDBLOCK || errno == EAGAIN) {
+                puts("all connections accepted"); 
+                break;
+            }
+            // failed to accept
+            else {
+                puts("error accepting connections");
+                break;
+            }
+        }
+        else {
+            // start monitoring the connection
+            non_blocking_socket(accept_res);                
+            struct epoll_event client_connection;
+            client_connection.data.fd = as_epoll_data(accept_res, EPOLL_PEER_FD);
+            client_connection.events = EPOLLIN | EPOLLET; 
+
+            // bind connection to epoll
+            int epoll_bind = epoll_ctl(epoll_c, EPOLL_CTL_ADD, accept_res, &client_connection);
+        }
+    }
+}
+
+
+
+// main I/O loop for the program
+void loop(int epoll_c, struct epoll_event* events) {
+    int num_changes = epoll_wait(epoll_c, events, MAX_EPOLL_EVENTS, EPOLL_TIMEOUT); 
+    printf("num changes %d\n", num_changes);
+    for(size_t i = 0; i < num_changes; i++) {
+        struct epoll_event epoll_e = events[i];     
+        int file_descriptor = as_custom_data(events[i].data.u64).fd;
+        int event_type = as_custom_data(events[i].data.u64).type;
+
+        printf("processing, fd: %d, et: %d \n", file_descriptor, event_type);
+
+        if(epoll_e.events & EPOLLERR) {
+            puts("error on epoll event");
+            close(file_descriptor);
+        }
+        else if(epoll_e.events & EPOLLHUP) {
+            puts("holdup error on epoll event");
+            close(file_descriptor);
+        }
+        // we have a pending connection on our socket
+        else if(event_type == EPOLL_LISTEN_FD) {
+            on_connection(epoll_c, file_descriptor);
+        }
+        // we have data on our socket
+        else if(event_type == EPOLL_PEER_FD) {
+            
+        }
+        else {
+            puts("faillthrough");
+            exit(1);
+        }
+    }
+}
+
+int main() {
+    int epoll_c = create_epoll_socket();
+    struct epoll_event* events;
+    events = calloc (MAX_EPOLL_EVENTS, sizeof events);
+
+    puts("running I/O loop.");    
+    while(1) {
+        loop(epoll_c, events);
+    }
+}

--- a/src/network.c
+++ b/src/network.c
@@ -6,6 +6,18 @@
 #include <sys/epoll.h>
 #include "./network.h"
 
+uint64_t as_epoll_data(int32_t fd, int32_t type) {
+    epoll_custom_data event_d = {fd, type};
+    uint64_t result;  
+    memcpy(&result, &event_d, sizeof(uint64_t));
+    return result;
+}
+epoll_custom_data as_custom_data(uint64_t epoll_data_result) {
+    epoll_custom_data result = {(int)0, (int)0};
+    memcpy(&result, &epoll_data_result, sizeof(uint64_t));
+    return result;
+}
+
 /* Makes a fcntl system call to mark a socket a non-blocking
  * We want to be able to handle multiple IO operations at the same time with epoll
  * https://man7.org/linux/man-pages/man2/fcntl.2.html
@@ -25,11 +37,12 @@ void non_blocking_socket(int socket) {
 
 /* Creates a TCP socket and binds it to port */
 int create_socket() {
-    const struct sockaddr_in server_adress = {
+    struct sockaddr_in6 server_adress = {
         AF_INET6,                       // use ipv6 resolution
-        (sa_family_t) LISTEN_PORT,      // port to listen on  
-        inet_addr("127.0.0.1")          // listen on localhost
-    };
+        htons(LISTEN_PORT),             // port to listen on  
+        0,                              // null pad for inet_pton command
+    }; 
+    inet_pton(AF_INET6, "::1", &server_adress.sin6_addr); // listen on localhost
 
     // try to allocate a TCP socket from OS
     int server_socket = socket(AF_INET6, SOCK_STREAM, 0);
@@ -37,7 +50,7 @@ int create_socket() {
         puts("failed to allocate socket");
         exit(1);
     }
-    
+
     // try to bind socket to port 
     int bind_res = bind(server_socket, (const struct sockaddr*) &server_adress, sizeof(server_adress));
     if(bind_res < 0) {
@@ -71,7 +84,7 @@ int create_epoll_socket() {
 
     // wrap server socket into an epoll event 
     struct epoll_event server_epoll; 
-    server_epoll.data.fd = EPOLL_LISTEN_FD; 
+    server_epoll.data.u64 = as_epoll_data(server_socket, EPOLL_LISTEN_FD); 
 
     // https://man7.org/linux/man-pages/man7/epoll.7.html
     // mark as edge-triggering with I/O in
@@ -80,6 +93,6 @@ int create_epoll_socket() {
         puts("failed to bind socket to epoll descriptor");
         exit(1);
     }
-    
+
     return epoll_descriptor;
 }

--- a/src/network.h
+++ b/src/network.h
@@ -1,4 +1,5 @@
 #include <stdio.h> 
+#include <string.h>
 #include <stdlib.h> 
 #include <fcntl.h>
 #include <arpa/inet.h> 
@@ -9,10 +10,24 @@
 enum {
     MAX_EPOLL_EVENTS = 50,
     MAX_LISTEN_BACKLOG = 50,
-    LISTEN_PORT = 8201,
+    LISTEN_PORT = 8100,
     EPOLL_LISTEN_FD = 1,  // mark epoll events for our socket with this code
     EPOLL_PEER_FD = 2,   // mark epoll events for peer connections with this code
+    EPOLL_TIMEOUT = 1000 // mark epoll to block this many ms until event is recieved
 };
+
+/* This is kind of a hack but basically the data from returned from an epoll event
+ * is a union of this type https://man7.org/linux/man-pages/man2/epoll_ctl.2.html.
+ * Ideally, we want to know both the file descriptor and what the descriptor is.
+ * The union is 64 bits so we can pack a 32 bit file_descriptor and a 32 bit custom user descriptor
+ */
+typedef struct epoll_custom_data {
+    int32_t fd;
+    int32_t type;
+} epoll_custom_data;
+
+uint64_t as_epoll_data(int32_t fd, int32_t type); 
+epoll_custom_data as_custom_data(uint64_t epoll_data_result);
 
 /* Makes a fcntl system call to mark a socket a non-blocking
  * We want to be able to handle multiple IO operations at the same time with epoll

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,4 +23,9 @@ add_test(
   COMMAND test_vector ${CRITERION_FLAGS}
 )
 
+add_executable(loop ../src/loop.c)
+target_link_libraries(loop
+    PRIVATE include_all
+)
+
 


### PR DESCRIPTION
rebase of https://github.com/olincollege/p2p-networking/pull/4 onto main


```loop.c``` is an example program to demonstrate how an event loop can be handled with ```epoll``` system calls. I ran the program and then simulated a client connection with ```nc ::1 8100``` from another terminal. 

The log from ```loop.c``` is as follows: 

```ruby
running I/O loop.
num changes 0
num changes 0
num changes 0
num changes 0
num changes 0
num changes 0
num changes 0
num changes 0
num changes 1
processing, fd: 3, et: 1 
attempting to accept connection
all connections accepted
num changes 0
num changes 0
num changes 0
```