### PR TITLE
Implement type agnostic hash tables

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -15,3 +15,17 @@ unsigned long djb2(unsigned char *str) {
     // NOLINTEND
 }
 
+// A version that takes in a generic array
+unsigned long djb2_bytes(void* bytes, size_t num) {
+    // NOLINTBEGIN
+    size_t hash = 5381;
+    char c = 0;
+    for (size_t i = 0; i < num; i++) {
+        // Treat bytes as an array of chars
+        c = ((char *) bytes)[i];
+        hash = ((hash << 5) + hash) + (size_t)c; /* hash * 33 + c */
+    }
+
+    return hash;
+    // NOLINTEND
+}

--- a/src/hash.h
+++ b/src/hash.h
@@ -8,3 +8,4 @@
 */
 unsigned long djb2(unsigned char *str); 
 
+unsigned long djb2_bytes(void* bytes, size_t num);

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -4,8 +4,9 @@
 
 /* The key/value container for our hash map */
 typedef struct kv_pair {
-    char* key; 
+    void* key; 
     void* value;
+    size_t key_size;
     size_t value_size; 
 } kv_pair; 
 
@@ -20,10 +21,10 @@ typedef struct hash_table {
 } hash_table;
 
 /* Sets a value in the hash table. The key and value is copied by value. */
-void set_value(hash_table* in_table, char* key, void* value, size_t value_size); 
+void set_value(hash_table* in_table, void* key, size_t key_size, void* value, size_t value_size); 
 
 /* Returns a key/value pair in the hash_table or a NULL padded struct if it does not exist */
-kv_pair* get_kv_pair(hash_table* in_table, char* key);
+kv_pair* get_kv_pair(hash_table* in_table, void* key, size_t key_size);
 
 
 /* Create a new hable */

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -4,20 +4,25 @@
 #include "../src/hash_table.h"
 
 // NOLINTBEGIN -- the magic constant warnings are useless here
+
+// Test that we can create a hash table, put in 2 values, and take out those
+// values.
 Test(test_map, simple_test) {
     hash_table table = make_table();
-    char* key1 = "key1";
-    char* key2 = "key2";
-    int val1 = 1;
-    int val2 = 2;
-    set_value(&table, key1, &val1, sizeof(val1));
-    set_value(&table, key2, &val2, sizeof(val2));
+    // char key1[] = {'k', 'e', 'y', '1'};
+    // char key2[] = {'k', 'e', 'y', '2'};
+    int key1 = 1; // We can now hash literally anything
+    int key2 = 2;
+    int val1 = 100;
+    int val2 = 200;
+    set_value(&table, &key1, sizeof(key1), &val1, sizeof(val1));
+    set_value(&table, &key2, sizeof(key2), &val2, sizeof(val2));
 
-    kv_pair* kv1 = get_kv_pair(&table, key1); 
+    kv_pair* kv1 = get_kv_pair(&table, &key1, sizeof(key1)); 
     int res1 = *(int*)kv1->value;
     cr_assert(eq(int, val1, res1));
 
-    kv_pair* kv2 = get_kv_pair(&table, key2); 
+    kv_pair* kv2 = get_kv_pair(&table, &key2, sizeof(key2)); 
     int res2 = *(int*)kv2->value;
     cr_assert(eq(int, val2, res2));
 
@@ -33,19 +38,20 @@ Test(test_map, advance_test) {
             char key[4] = "abc";
             key[3] = 'a' + idx;
             key[4] = '\0';
-            set_value(&table, key, &idx, sizeof(idx));
+            set_value(&table, key, strlen(key)+1, &idx, sizeof(idx));
         }
         for(size_t idx = 0; idx < iters; idx++) {
             char key[4] = "abc";
             key[3] = 'a' + idx;
             key[4] = '\0';
-            kv_pair* kv = get_kv_pair(&table, key); 
+            kv_pair* kv = get_kv_pair(&table, key, strlen(key)+1); 
             int actual_value = *(int*)kv->value;
             cr_assert(eq(int, idx, actual_value));
         }
         hash_dealloc(&table);
     }
 }
+
 
 // Tested with valgrind against memory leaks
 Test(test_map, memory_leak_test) {
@@ -55,14 +61,14 @@ Test(test_map, memory_leak_test) {
         char* key2 = "key2";
         int val1 = 1;
         int val2 = 2;
-        set_value(&table, key1, &val1, sizeof(val1));
-        set_value(&table, key2, &val2, sizeof(val2));
+        set_value(&table, key1, strlen(key1)+1, &val1, sizeof(val1));
+        set_value(&table, key2, strlen(key2)+1, &val2, sizeof(val2));
 
-        kv_pair* kv1 = get_kv_pair(&table, key1); 
+        kv_pair* kv1 = get_kv_pair(&table, key1, strlen(key1)+1); 
         int res1 = *(int*)kv1->value;
         cr_assert(eq(int, val1, res1));
 
-        kv_pair* kv2 = get_kv_pair(&table, key2); 
+        kv_pair* kv2 = get_kv_pair(&table, key2, strlen(key2)+1); 
         int res2 = *(int*)kv2->value;
         cr_assert(eq(int, val2, res2));
 


### PR DESCRIPTION
The hash table has been modified to work with any datatype that occupies a continuous span in memory (no following pointers).

This means that keys can be any type or an array of that type.

Fixes #14 