### PR TITLE
add failing test for hash_table

### DIFF
--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -22,7 +22,8 @@ kv_pair* get_kv_pair(hash_table* in_table, void* key, size_t key_size) {
     // walk the bucket
     for(size_t index = 0; index < (in_table->buckets[bucket].size); index++) {
         char* ret_key = in_table->buckets[bucket].arr[index].key; 
-        if(strcmp(key, ret_key) == 0) {
+        size_t ret_key_size = in_table->buckets[bucket].arr[index].key_size;
+        if(ret_key_size == key_size && memcmp(key, ret_key, key_size) == 0) {
             return &in_table->buckets[bucket].arr[index];
         }
     }

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -29,6 +29,30 @@ Test(test_map, simple_test) {
     hash_dealloc(&table);
 }
 
+// the presence of a null-terminator char should not affect anything
+Test(test_map, null_terminated_data) {
+    hash_table table = make_table();
+    for(size_t total_iter = 0; total_iter < 26; total_iter++) {
+        char keyx[3] = {'\0', 'a'+total_iter%26, 'b'};
+        int datax = total_iter;
+        set_value(&table, keyx, sizeof(char)*3, &datax, sizeof(datax));
+    }
+    char key1[3] = {'\0', 'a', 'b'};
+    char key2[3] = {'\0', 'b', 'b'};
+
+    kv_pair* kv1 = get_kv_pair(&table, &key1, sizeof(char)*3); 
+    kv_pair* kv2 = get_kv_pair(&table, &key2, sizeof(char)*3); 
+
+    int res1 = *(int*)kv1->value;
+    int res2 = *(int*)kv2->value;
+
+    cr_assert(eq(int, res1, 0));
+    cr_assert(eq(int, res2, 1));
+
+    hash_dealloc(&table);
+
+}
+
 // Tested with valgrind against memory leaks
 Test(test_map, advance_test) {
     for(size_t total_iter = 0; total_iter < 1000; total_iter++) {


### PR DESCRIPTION
when we changed it to be any type of data for the key, we should switch to memcmp instead of strcmp since null-terminator chars should have no effect now. 