### PR TITLE
Collect and Remove Hash Table Methods

### DIFF
--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -44,6 +44,7 @@ void remove_kv_pair(hash_table* in_table, void* key, size_t key_size) {
             // remove element 
             free(pair.key);
             free(pair.value);
+            in_table->num_elements --; 
         }
         else {
             // keep key/value pair 

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -55,19 +55,19 @@ void remove_kv_pair(hash_table* in_table, void* key, size_t key_size) {
     in_table->buckets[bucket] = without_key;
 }
 
-/* Returns an array with all of the key/value pairs */
-kv_pair* collect(hash_table* in_table) {
-   kv_pair* return_array = malloc(sizeof(kv_pair) * in_table->num_elements); 
-   kv_pair* array_ref = return_array; 
-   // walk the buckets
-   for(size_t bucket = 0; bucket < in_table->bucket_size; bucket++) {
+/* Returns a vector with all of the key/value pairs.
+ * Note that the keys and values are pointers and may be invalidated with any future hash_table operations. 
+ */
+vector_kv_pair collect(hash_table* in_table) {
+    vector_kv_pair collected = new_vec_kv_pair();
+    // walk the buckets
+    for(size_t bucket = 0; bucket < in_table->bucket_size; bucket++) {
         // walk the elements
         for(size_t elem = 0; elem < in_table->buckets[bucket].size; elem++) {
-            *array_ref = in_table->buckets[bucket].arr[elem];
-            array_ref++;
+            push_vec_kv_pair(&collected, in_table->buckets[bucket].arr[elem]);
         }
-   }
-   return return_array;
+    }
+    return collected;
 }
 
 /* Frees the data used by the hash table */

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -58,7 +58,7 @@ void remove_kv_pair(hash_table* in_table, void* key, size_t key_size) {
 /* Returns a vector with all of the key/value pairs.
  * Note that the keys and values are pointers and may be invalidated with any future hash_table operations. 
  */
-vector_kv_pair collect(hash_table* in_table) {
+vector_kv_pair collect_table(hash_table* in_table) {
     vector_kv_pair collected = new_vec_kv_pair();
     // walk the buckets
     for(size_t bucket = 0; bucket < in_table->bucket_size; bucket++) {

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -23,10 +23,15 @@ typedef struct hash_table {
 /* Sets a value in the hash table. The key and value is copied by value. */
 void set_value(hash_table* in_table, void* key, size_t key_size, void* value, size_t value_size); 
 
+/* Removes a key from the hash_table or does nothing is such key does not exist */
+void remove_kv_pair(hash_table* in_table, void* key, size_t key_size);
+
 /* Returns a key/value pair in the hash_table or a NULL padded struct if it does not exist */
 kv_pair* get_kv_pair(hash_table* in_table, void* key, size_t key_size);
 
-
+/* Returns an array with all of the key/value pairs */
+kv_pair* collect(hash_table* in_table) {
+ 
 /* Create a new hable */
 hash_table make_table(); 
 

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -29,8 +29,10 @@ void remove_kv_pair(hash_table* in_table, void* key, size_t key_size);
 /* Returns a key/value pair in the hash_table or a NULL padded struct if it does not exist */
 kv_pair* get_kv_pair(hash_table* in_table, void* key, size_t key_size);
 
-/* Returns an array with all of the key/value pairs */
-kv_pair* collect(hash_table* in_table) {
+/* Returns a vector with all of the key/value pairs.
+ * Note that the keys and values are pointers and may be invalidated with any future hash_table operations. 
+ */
+vector_kv_pair collect(hash_table* in_table); 
  
 /* Create a new hable */
 hash_table make_table(); 

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -32,7 +32,7 @@ kv_pair* get_kv_pair(hash_table* in_table, void* key, size_t key_size);
 /* Returns a vector with all of the key/value pairs.
  * Note that the keys and values are pointers and may be invalidated with any future hash_table operations. 
  */
-vector_kv_pair collect(hash_table* in_table); 
+vector_kv_pair collect_table(hash_table* in_table); 
  
 /* Create a new hable */
 hash_table make_table(); 

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -75,14 +75,14 @@ Test(test_map, remove_collect_elements) {
     cr_assert(eq(int, 1, elements.size));
     cr_assert(eq(int, 0, memcmp(elements.arr[0].value, &data1, sizeof(data1))));
 
+    // removing non-existant key should not do anything
+    int no_exist = 0;
+    remove_kv_pair(&table, &no_exist, sizeof(no_exist));
+    cr_assert(eq(int, 1, table.num_elements));
+
     // hash table should be empty now
     remove_kv_pair(&table, key1, sizeof(key1));
     cr_assert(eq(int, 0, table.num_elements));
-
-
-    // table should be empty
-
-
 
     hash_dealloc(&table);
 }

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -53,6 +53,22 @@ Test(test_map, null_terminated_data) {
 
 }
 
+// test removing and collecting elements 
+Test(test_map, remove_collect_elements) {
+    hash_table table = make_table(); 
+    char key1[] = {'\0', 'a', 'b', 'c', 'd'};
+    char data1[] = {'a', 'b', 'c', 'd', 'e'};
+    
+    // hash_table is empty at the start
+    cr_assert(eq(int, 0, table.num_elements));
+
+    // hash table has one element now
+    set_value(&table, key1, sizeof(key1), data1, sizeof(data1));
+    cr_assert(eq(int, 0, table.num_elements));
+
+    hash_dealloc(&table);
+}
+
 // Tested with valgrind against memory leaks
 Test(test_map, advance_test) {
     for(size_t total_iter = 0; total_iter < 1000; total_iter++) {

--- a/test/test_hash_table.c
+++ b/test/test_hash_table.c
@@ -64,7 +64,25 @@ Test(test_map, remove_collect_elements) {
 
     // hash table has one element now
     set_value(&table, key1, sizeof(key1), data1, sizeof(data1));
+    cr_assert(eq(int, 1, table.num_elements));
+    
+    // table should still have one element
+    set_value(&table, key1, sizeof(key1), data1, sizeof(data1));
+    cr_assert(eq(int, 1, table.num_elements));
+
+    // collect should have one element
+    vector_kv_pair elements = collect_table(&table);
+    cr_assert(eq(int, 1, elements.size));
+    cr_assert(eq(int, 0, memcmp(elements.arr[0].value, &data1, sizeof(data1))));
+
+    // hash table should be empty now
+    remove_kv_pair(&table, key1, sizeof(key1));
     cr_assert(eq(int, 0, table.num_elements));
+
+
+    // table should be empty
+
+
 
     hash_dealloc(&table);
 }


### PR DESCRIPTION
Implements ```void remove_kv_pair(hash_table* in_table, void* key, size_t key_size);```
Implements ```vector_kv_pair collect_table(hash_table* in_table);```

The tests are a little weak, will add more later and re-test for memory leaks 