### PR TITLE
Make port number in `loop.c` configurable (#28)

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -1,4 +1,5 @@
 #include <arpa/inet.h>
+#include <bits/getopt_core.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -82,8 +83,41 @@ void loop(int epoll_c, struct epoll_event *events) {
   }
 }
 
-int main() {
-  int epoll_c = create_epoll_socket();
+int main(int argc, char *argv[]) {
+
+  /* Process CLI Arguments
+   *
+   * -S server mode, uses a fixed port
+   */
+  int is_server = 0; // 0 is client, 1 is server
+
+  int arg = 0;
+  while ((arg = getopt(argc, argv, "S")) != EOF) {
+    // NOLINTBEGIN -- Switch is extendable to more CLI args. Linter doesn't
+    //                like 1 arg switch though.
+    switch (arg) {
+    case 'S':
+      is_server = 1;
+      break;
+    }
+    // NOLINTEND
+  }
+
+  // NOLINTBEGIN -- Keeping this in case we ever want to read positional
+  //                arguments. Linter does not like that these values are never
+  //                read or used.
+  argc -= optind;
+  argv += optind;
+  // NOLINTEND
+
+  // Begin the actual program
+
+  int epoll_c = 0;
+  if (is_server) {
+    epoll_c = create_epoll_socket(SERVER_LISTEN_PORT);
+  } else {
+    epoll_c = create_epoll_socket(0);
+  }
   struct epoll_event events[MAX_EPOLL_EVENTS];
 
   puts("running I/O loop.");

--- a/src/network.c
+++ b/src/network.c
@@ -2,6 +2,7 @@
 
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/epoll.h>
@@ -41,12 +42,15 @@ void non_blocking_socket(int socket) {
   }
 }
 
-/* Creates a TCP socket and binds it to port */
-int create_socket() {
+/* Creates a TCP socket and binds it to port
+ *
+ * If port is 0, binds socket to a random port.
+ */
+int create_socket(uint16_t port) {
   struct sockaddr_in6 server_adress;
   memset(&server_adress, '\0', sizeof(server_adress));  // NOLINT
   server_adress.sin6_family = AF_INET6;                 // use ipv6 resolution
-  server_adress.sin6_port = htons(LISTEN_PORT);         // port to listen on
+  server_adress.sin6_port = htons(port);                // port to listen on
   inet_pton(AF_INET6, "::1", &server_adress.sin6_addr); // listen on localhost
 
   // try to allocate a TCP socket from OS
@@ -74,10 +78,12 @@ int create_socket() {
 /* Create an epoll container for the TCP listening socket.
  * We can use it to drive an I/O loop with many different types of file
  * descriptors.
+ *
+ * If port is 0, binds socket to a random port.
  */
-int create_epoll_socket() {
+int create_epoll_socket(uint16_t port) {
   // create a socket for our server
-  int server_socket = create_socket();
+  int server_socket = create_socket(port);
   non_blocking_socket(server_socket);
 
   // create an epoll container for multiplexing I/O

--- a/src/network.h
+++ b/src/network.h
@@ -12,7 +12,7 @@
 enum {
   MAX_EPOLL_EVENTS = 50,
   MAX_LISTEN_BACKLOG = 50,
-  LISTEN_PORT = 8100,
+  SERVER_LISTEN_PORT = 8100,
   EPOLL_LISTEN_FD = 1, // mark epoll events for our socket with this code
   EPOLL_PEER_FD = 2,   // mark epoll events for peer connections with this code
   EPOLL_TIMEOUT =
@@ -41,13 +41,13 @@ epoll_custom_data as_custom_data(uint64_t epoll_data_result);
 void non_blocking_socket(int socket);
 
 /* Creates a TCP socket and binds it to port */
-int create_socket();
+int create_socket(uint16_t port);
 
 /* Create an epoll container for the TCP listening socket.
  * We can use it to drive an I/O loop with many different types of file
  * descriptors.
  */
-int create_epoll_socket();
+int create_epoll_socket(uint16_t port);
 
 /* "Peek" a socket to see if a full message is availabe
  * Implemented to make sure that incomplete messages are not cleared out before


### PR DESCRIPTION
* Add CLI argument to loop to run in server mode

* Make port selectable in socket creation functions

* Implement client/server mode in `loop.c`

* Fix typing issue in network code

Used an int for network port when an unsigned 16 bit int should be used instead

* Fix minor typing and linting issues