### PR TITLE
Fix incorrect field names and pointer issues

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -26,35 +26,37 @@ void dealloc_state(client_state *state) {
 void add_piece_have(client_state *state, void *piece, size_t piece_size) {
   char *piece_hash[SHA256_DIGEST_LENGTH];
   sha256(piece, piece_size, piece_hash);
-  set_value(state.have, piece_hash, SHA256_DIGEST_LENGTH, piece, piece_size);
+  set_value(&state->pieces_have,
+            piece_hash, SHA256_DIGEST_LENGTH,
+            piece, piece_size);
 }
 
 void remove_piece_have(client_state *state, void *piece, size_t piece_size) {
   char *piece_hash[SHA256_DIGEST_LENGTH];
   sha256(piece, piece_size, piece_hash);
-  remove_kv_pair(state.have, piece_hash, SHA256_DIGEST_LENGTH);
+  remove_kv_pair(&state->pieces_have, piece_hash, SHA256_DIGEST_LENGTH);
 }
 
 void add_piece_want(client_state *state, unsigned char *hash) {
-  set_value(state.pieces_want, hash, SHA256_DIGEST_LENGTH, NULL, 1);
+  set_value(&state->pieces_want, hash, SHA256_DIGEST_LENGTH, NULL, 1);
 }
 
 void remove_piece_want(client_state *state, unsigned char *hash) {
-  remove_kv_pair(state.pieces_want, hash, SHA256_DIGEST_LENGTH);
+  remove_kv_pair(&state->pieces_want, hash, SHA256_DIGEST_LENGTH);
 }
 
 void add_file_descriptor(client_state *state, int file_descriptor) {
-  set_value(state.file_descriptors, &file_descriptor, sizeof(int), NULL, 1);
+  set_value(&state->file_descriptors, &file_descriptor, sizeof(int), NULL, 1);
 }
 
 void remove_file_descriptor(client_state *state, int file_descriptor) {
-  remove_kv_pair(state.file_descriptors, &file_descriptor, sizeof(int));
+  remove_kv_pair(&state->file_descriptors, &file_descriptor, sizeof(int));
 }
 
 void add_port(client_state *state, uint16_t port) {
-  set_value(state.ports, &port, sizeof(uint16_t), NULL, 1);
+  set_value(&state->ports, &port, sizeof(uint16_t), NULL, 1);
 }
 
 void remove_port(client_state *state, uint16_t port) {
-  remove_kv_pair(state.ports, &port, sizeof(uint16_t));
+  remove_kv_pair(&state->ports, &port, sizeof(uint16_t));
 }

--- a/src/state.h
+++ b/src/state.h
@@ -33,10 +33,10 @@ void add_piece_have(client_state *state, void *piece, size_t piece_size);
 void remove_piece_have(client_state *state, void *piece, size_t piece_size);
 
 /* Add a wanted piece to client state. */
-void add_piece_want(client_state *state, unsigned long hash);
+void add_piece_want(client_state *state, unsigned char *hash);
 
 /* Remove a wanted piece from client state. */
-void remove_piece_want(client_state *state, unsigned long hash);
+void remove_piece_want(client_state *state, unsigned char *hash);
 
 /* Add a file descriptor. */
 void add_file_descriptor(client_state *state, int file_descriptor);


### PR DESCRIPTION
Fixes a few issues in `state.c` 
- Argument `state` in several function is a pointer to a `client_state`, not a `client_state` itself.
- Fixed invalid field references
- Fixed conflicting type signatures

Fixes #36 