### PR TITLE
Implement Peer Exchange with Test Coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(SoftSysA02
 )
 
 set(CMAKE_C_STANDARD 17)
-
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=10000000000000")
 set(CMAKE_C_FLAGS "-isystem/usr/local/Cellar/criterion/2.4.1_1/include -Wall -Wextra -pedantic -Wshadow -Wconversion -Wunreachable-code -g")
 
 set(CMAKE_C_CLANG_TIDY

--- a/src/state.c
+++ b/src/state.c
@@ -119,11 +119,12 @@ void peer_exchange(client_state *state) {
   for (size_t peer = 0; peer < clients_connected.size; peer++) {
     int peer_fd = *(int *)clients_connected.arr[peer].key;
     ssize_t send_res = write(peer_fd, message, peer_message_size);
+    printf("starting to write to peer\n");
     if (send_res < 0) {
-      printf("failed to write peer list, closing fd: %d", peer_fd);
+      printf("failed to write peer list, closing fd: %d\n, err: %d", peer_fd, (int)send_res);
       close(peer_fd);
     } else {
-      printf("sent peer list to fd: %d", peer_fd);
+      printf("sent peer list to fd: %d\n", peer_fd);
     }
   }
 

--- a/src/state.c
+++ b/src/state.c
@@ -79,7 +79,9 @@ void remove_piece_want(client_state *state, unsigned char *hash) {
 }
 
 void add_file_descriptor(client_state *state, int file_descriptor) {
-  set_value(&state->file_descriptors, &file_descriptor, sizeof(int), NULL, 1);
+  int empty = 0;
+  set_value(&state->file_descriptors, &file_descriptor, sizeof(int), &empty,
+            sizeof(empty));
 }
 
 void remove_file_descriptor(client_state *state, int file_descriptor) {
@@ -87,7 +89,8 @@ void remove_file_descriptor(client_state *state, int file_descriptor) {
 }
 
 void add_port(client_state *state, uint16_t port) {
-  set_value(&state->ports, &port, sizeof(uint16_t), NULL, 1);
+  int empty = 0;
+  set_value(&state->ports, &port, sizeof(uint16_t), &empty, sizeof(empty));
 }
 
 void remove_port(client_state *state, uint16_t port) {

--- a/src/state.c
+++ b/src/state.c
@@ -1,3 +1,4 @@
+#include <arpa/inet.h>
 #include <openssl/sha.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -91,4 +92,40 @@ void add_port(client_state *state, uint16_t port) {
 
 void remove_port(client_state *state, uint16_t port) {
   remove_kv_pair(&state->ports, &port, sizeof(uint16_t));
+}
+
+void peer_exchange(client_state *state) {
+  vector_kv_pair clients_connected = collect_table(&state->file_descriptors);
+  vector_kv_pair known_ports = collect_table(&state->ports);
+
+  // craft the peer message
+  size_t peer_message_size =
+      sizeof(peer_message) + sizeof(peer_info) * known_ports.size;
+  peer_message *message = malloc(peer_message_size);
+  message->message_size =
+      (uint32_t)(peer_message_size - sizeof(message->message_size));
+  message->type = 2;
+  for (size_t port = 0; port < known_ports.size; port++) {
+    struct sockaddr_in6 addr;
+    inet_pton(AF_INET6, "::1", &addr.sin6_addr);
+    peer_info info = {addr.sin6_addr, *(in_port_t *)known_ports.arr[port].key};
+    message->peers[port] = info;
+  }
+
+  // send the peer message
+  for (size_t peer = 0; peer < clients_connected.size; peer++) {
+    int peer_fd = *(int *)clients_connected.arr[peer].key;
+    ssize_t send_res = write(peer_fd, message, peer_message_size);
+    if (send_res < 0) {
+      printf("failed to write peer list, closing fd: %d", peer_fd);
+      close(peer_fd);
+    } else {
+      printf("sent peer list to fd: %d", peer_fd);
+    }
+  }
+
+  // cleanup
+  free_vec_kv_pair(&clients_connected);
+  free_vec_kv_pair(&known_ports);
+  free(message);
 }

--- a/src/state.c
+++ b/src/state.c
@@ -121,7 +121,8 @@ void peer_exchange(client_state *state) {
     ssize_t send_res = write(peer_fd, message, peer_message_size);
     printf("starting to write to peer\n");
     if (send_res < 0) {
-      printf("failed to write peer list, closing fd: %d\n, err: %d", peer_fd, (int)send_res);
+      printf("failed to write peer list, closing fd: %d\n, err: %d", peer_fd,
+             (int)send_res);
       close(peer_fd);
     } else {
       printf("sent peer list to fd: %d\n", peer_fd);

--- a/src/state.h
+++ b/src/state.h
@@ -50,3 +50,6 @@ void add_port(client_state *state, uint16_t port);
 
 /* Remove a port. */
 void remove_port(client_state *state, uint16_t port);
+
+/* Exchanges peer list with connected clients */
+void peer_exchange(client_state *state);

--- a/test/test_state.c
+++ b/test/test_state.c
@@ -2,6 +2,8 @@
 #include <criterion/new/assert.h>
 #include <criterion/redirect.h>
 #include <stdlib.h>
+#include <fcntl.h>
+
 
 #include "../src/state.h"
 
@@ -16,16 +18,29 @@ Test(test_state, test_random_state) {
     cr_assert(eq(int, WANT_AMOUNT, state.pieces_want.num_elements));
 }
 
-Test(test_state, test_peer_exhange, .init = cr_redirect_stdout) {
-   FILE* f_stdin = cr_get_redirected_stdin(); 
-   int fin_fd = fileno(f_stdin);
+Test(test_state, test_peer_exhange, .init = cr_redirect_stdin) {
+   remove("/tmp/test_peer_exchange");
+   int fd_in = open("/tmp/test_peer_exchange", O_CREAT | O_APPEND | O_RDWR);    
+   if(fd_in < 0) {
+        puts("failed to open test_state fd");
+   }
 
-    // say we know about 4 random ports
+   // say we know about 4 random ports
    client_state state = new_state();
    add_port(&state, 1);
    add_port(&state, 2);
    add_port(&state, 3);
    add_port(&state, 4);
+
+   // say we are connected to a "client" mocked as stdin
+   add_file_descriptor(&state, fd_in);
+
+   // attempt to broadcast to fds
+   peer_exchange(&state);
+
+   //(void)fflush(stdout);
+   //(void)fclose(stdout);
+
 }
 
 // NOLINTEND

--- a/test/test_state.c
+++ b/test/test_state.c
@@ -21,41 +21,62 @@ Test(test_state, test_random_state) {
 }
 
 Test(test_state, test_peer_exhange) {
-   remove("/tmp/test_peer_exchange");
-   int fd_in = open("/tmp/test_peer_exchange", O_CREAT | O_APPEND | O_RDWR, S_IRUSR | S_IWUSR);    
-   if(fd_in < 0) {
+    remove("/tmp/test_peer_exchange");
+    int fd_in = open("/tmp/test_peer_exchange", O_CREAT | O_APPEND | O_RDWR, S_IRUSR | S_IWUSR);    
+    if(fd_in < 0) {
         puts("failed to open test_state fd");
-   }
+    }
 
-   // say we know about 4 random ports
-   client_state state = new_state();
-   add_port(&state, 1);
-   add_port(&state, 2);
-   add_port(&state, 3);
-   add_port(&state, 4);
+    // say we know about 4 random ports
+    client_state state = new_state();
+    add_port(&state, 1);
+    add_port(&state, 2);
+    add_port(&state, 3);
+    add_port(&state, 4);
 
-   // say we are connected to a "client" mocked as stdin
-   add_file_descriptor(&state, fd_in);
+    // say we are connected to a "client" mocked as stdin
+    add_file_descriptor(&state, fd_in);
 
-   // attempt to broadcast to fds
-   peer_exchange(&state);
-   close(fd_in);
+    // attempt to broadcast to fds
+    peer_exchange(&state);
+    close(fd_in);
 
-   // assert against the written message
-   char* buffer = malloc(1024*1024); 
-   size_t bytes_read = 0; 
-   FILE* fd_read = fopen("/tmp/test_peer_exchange", "r");
-   while(!feof(fd_read)) {
-     char ch = fgetc(fd_read); 
-     buffer[bytes_read] = ch;
-     bytes_read++;
-   }
-   fclose(fd_read);
-   peer_message* message = malloc(bytes_read);
-   memcpy(message, buffer, bytes_read);
+    // recover the written message
+    char* buffer = malloc(1024*1024); 
+    size_t bytes_read = 0; 
+    FILE* fd_read = fopen("/tmp/test_peer_exchange", "r");
+    while(1) {
+        char ch = fgetc(fd_read); 
+        if(feof(fd_read)) {
+            break;
+        }
+        buffer[bytes_read] = ch;
+        bytes_read++;
+    }
+    fclose(fd_read);
+    peer_message* message = malloc(bytes_read);
+    memcpy(message, buffer, bytes_read);
 
-   free(message);
-   free(buffer);
+    // assert against the written message
+    cr_assert(eq(int, sizeof(peer_message) + 4*sizeof(peer_info), bytes_read));
+    cr_assert(eq(int, 2, (int)message->type)); 
+
+    in_port_t port_1 = message->peers[0].addr_port;
+    in_port_t port_2 = message->peers[1].addr_port;
+    in_port_t port_3 = message->peers[2].addr_port;
+    in_port_t port_4 = message->peers[3].addr_port;
+
+
+    // ordering not guaranteed by the hash_map
+    cr_assert(eq(int, 1, port_1 == 1 || port_2 == 1 || port_3 == 1 || port_4 == 1)); 
+    cr_assert(eq(int, 1, port_1 == 2 || port_2 == 2 || port_3 == 2 || port_4 == 2)); 
+    cr_assert(eq(int, 1, port_1 == 3 || port_2 == 3 || port_3 == 3 || port_4 == 3)); 
+    cr_assert(eq(int, 1, port_1 == 4 || port_2 == 4 || port_3 == 4 || port_4 == 4)); 
+
+    // cleanup
+    free(message);
+    free(buffer);
+    dealloc_state(&state);
 }
 
 // NOLINTEND

--- a/test/test_state.c
+++ b/test/test_state.c
@@ -59,6 +59,7 @@ Test(test_state, test_peer_exhange) {
 
     // assert against the written message
     cr_assert(eq(int, sizeof(peer_message) + 4*sizeof(peer_info), bytes_read));
+    cr_assert(eq(int, sizeof(peer_message) + 4*sizeof(peer_info) - sizeof(message->message_size), (int)message->message_size));
     cr_assert(eq(int, 2, (int)message->type)); 
 
     in_port_t port_1 = message->peers[0].addr_port;

--- a/test/test_state.c
+++ b/test/test_state.c
@@ -1,5 +1,6 @@
 #include <criterion/criterion.h>
 #include <criterion/new/assert.h>
+#include <criterion/redirect.h>
 #include <stdlib.h>
 
 #include "../src/state.h"
@@ -14,4 +15,17 @@ Test(test_state, test_random_state) {
     cr_assert(eq(int, HAVE_AMOUNT, state.pieces_have.num_elements));
     cr_assert(eq(int, WANT_AMOUNT, state.pieces_want.num_elements));
 }
+
+Test(test_state, test_peer_exhange, .init = cr_redirect_stdout) {
+   FILE* f_stdin = cr_get_redirected_stdin(); 
+   int fin_fd = fileno(f_stdin);
+
+    // say we know about 4 random ports
+   client_state state = new_state();
+   add_port(&state, 1);
+   add_port(&state, 2);
+   add_port(&state, 3);
+   add_port(&state, 4);
+}
+
 // NOLINTEND


### PR DESCRIPTION
Implements peer exchange with robust test coverage by mocking socket connections by using a file descriptor attached to a temporary file. 


Closes #33 