### PR TITLE
Add ourselves

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -120,20 +120,18 @@ int main(int argc, char *argv[]) {
 
   // Begin the actual program
 
-  int epoll_c = 0;
-  if (is_server) {
-    epoll_c = create_epoll_socket(SERVER_LISTEN_PORT);
-  } else {
-    epoll_c = create_epoll_socket(0);
-  }
+  our_server server = create_epoll_socket(is_server ? SERVER_LISTEN_PORT : 0);
+  int epoll_c = server.file_descriptor;
+  add_port(&state, server.port); // add ourselves to the peer broadcast
+
   struct epoll_event events[MAX_EPOLL_EVENTS];
 
-  puts("running I/O loop.");
+  printf("running I/O loop on port %d!\n", (int)server.port);
   size_t iter = 0;
   const size_t BROADCAST_TIMEOUT = 60; // broadcast every 60sec
   while (1) {
     iter++;
-    if(iter % BROADCAST_TIMEOUT) {
+    if(!(iter % BROADCAST_TIMEOUT)) {
        puts("starting broadcast of want pieces");
        broadcast_want(&state);
        puts("starting broadcast of peer exchange");

--- a/src/loop.h
+++ b/src/loop.h
@@ -12,11 +12,7 @@ void on_connection(int epoll_c, int file_descriptor);
 void loop(int epoll_c, struct epoll_event *events, client_state* state);
 
 /* Read a message from a client and update the state */
-<<<<<<< HEAD
 void read_message(int file_descriptor, int epoll_fd, client_state *state);
-=======
-void read_message(int file_descriptor, client_state *state);
->>>>>>> 5600a5c (add loop.h forward declarations)
 
 /* Connect to a peer
  * Returns file descriptor if successful, 0 if failed

--- a/src/loop.h
+++ b/src/loop.h
@@ -12,7 +12,11 @@ void on_connection(int epoll_c, int file_descriptor);
 void loop(int epoll_c, struct epoll_event *events, client_state* state);
 
 /* Read a message from a client and update the state */
+<<<<<<< HEAD
 void read_message(int file_descriptor, int epoll_fd, client_state *state);
+=======
+void read_message(int file_descriptor, client_state *state);
+>>>>>>> 5600a5c (add loop.h forward declarations)
 
 /* Connect to a peer
  * Returns file descriptor if successful, 0 if failed

--- a/src/network.h
+++ b/src/network.h
@@ -21,6 +21,12 @@ enum {
   // this is a little more than needed because the type is only one byte
 };
 
+/* Information to describe oursevles to other peers */
+typedef struct our_server {
+    uint16_t port; 
+    int file_descriptor;
+} our_server;
+
 /* This is kind of a hack but basically the data from returned from an epoll
  * event is a union of this type
  * https://man7.org/linux/man-pages/man2/epoll_ctl.2.html. Ideally, we want to
@@ -47,13 +53,13 @@ void non_blocking_socket(int socket);
 void large_buffer_socket(int socket);
 
 /* Creates a TCP socket and binds it to port */
-int create_socket(uint16_t port);
+our_server create_socket(uint16_t port);
 
 /* Create an epoll container for the TCP listening socket.
  * We can use it to drive an I/O loop with many different types of file
  * descriptors.
  */
-int create_epoll_socket(uint16_t port);
+our_server create_epoll_socket(uint16_t port);
 
 /* "Peek" a socket to see if a full message is availabe
  * Implemented to make sure that incomplete messages are not cleared out before

--- a/test/test_network.c
+++ b/test/test_network.c
@@ -13,7 +13,7 @@ Test(test_socket, check_expand_socket_buffer) {
         // make sure that we can expand socket buffer past 1MB 
 
         // get a new socket
-        int sock = create_socket(0); 
+        int sock = create_socket(0).file_descriptor; 
 
         // look at the default buffer size
         int original_rec_buffer = 0;


### PR DESCRIPTION
Adds ourselves to the peer list and determines what port we are listening on 


example:
```ruby
(base) daniel-sudz@daniel-sudz:~/Desktop/p2p-networking/build/test$ ./loop
running I/O loop on port 59193!
num changes 0
num changes 0
^C
(base) daniel-sudz@daniel-sudz:~/Desktop/p2p-networking/build/test$ ./loop
running I/O loop on port 44297!
num changes 0
^C
(base) daniel-sudz@daniel-sudz:~/Desktop/p2p-networking/build/test$ ./loop -S
running I/O loop on port 8100!
num changes 0
num changes 0

```
